### PR TITLE
Powerpoint decorations

### DIFF
--- a/src/lib/shapes/cylinder.typ
+++ b/src/lib/shapes/cylinder.typ
@@ -1,0 +1,101 @@
+#import "/src/coordinate.typ"
+#import "/src/draw.typ": *
+#import "/src/styles.typ"
+#import "/src/util.typ"
+#import "/src/vector.typ"
+
+#let _cetz-content = content
+#let _cetz-anchor = anchor
+
+#let cylinder-default-style = (
+  head-fill: auto,
+  head-radius: auto,
+  content-box: (inset: 0.5em),
+  stroke: (join: "round"),
+  size: (4,3)
+)
+
+#let cylinder(
+  pt,
+  name: none,
+  content: none,
+  anchor: none,
+  ..style,
+) = {
+  // validate coordinates
+  let _ = coordinate.resolve-system(pt)
+  group(name: name, anchor: anchor, ctx => {
+    let (ctx, pt) = coordinate.resolve(ctx, pt)
+    let style = styles.resolve(
+      ctx.style, merge: style.named(), root: "cylinder", base: cylinder-default-style
+    )
+    let (width, height) = style.size
+    let center-pt = vector.add(pt, (width/2, -height/2))
+    // Ensure the center anchor is used by default
+    translate(vector.sub(pt, center-pt))
+    // `head-radius` mimics the behavior of ppt to determine sizing
+    let head-radius = style.head-radius
+    if head-radius == auto {
+      head-radius = calc.min(width, height) / 4
+    }
+    if type(head-radius) == ratio {
+      head-radius = (head-radius * 1em).em * height
+    } else {
+      head-radius = util.resolve-number(ctx, head-radius)
+    }
+    let bottom-left = vector.sub(pt, (0, height))
+    let bottom-right = vector.add(bottom-left, (width, 0))
+    let top-right = vector.add(pt, (width, 0))
+    circle(
+      bottom-left,
+      anchor: "west",
+      radius: (width/2, head-radius),
+      stroke: (dash: "dashed"),
+      z: 50,
+    )
+    merge-path(
+      {
+        line(pt, bottom-left)
+        arc(
+          bottom-left,
+          start: 180deg,
+          delta: 180deg,
+          radius: (width/2, head-radius),
+        )
+        line(bottom-right, top-right)
+      },
+      ..style,
+    )
+    if style.head-fill == auto {
+      style.head-fill = style.fill
+    }
+    circle(pt, ..style, fill: style.head-fill, anchor: "west", radius: (width/2, head-radius))
+    if content != none {
+      let (width, height) = (width, height).map(el => util.resolve-number(ctx, el) * ctx.length)
+      let content = box(width: width, height: height, ..style.content-box, content)
+      _cetz-content(pt, bottom-right, content, ..style, anchor: "west")
+    }
+    let mid-top = vector.add(pt, (width/2, 0))
+    let mid-left = vector.add(pt, (0, -height/2))
+    let anchors = (
+      west: mid-left,
+      east: vector.add(mid-left, (width, 0)),
+      north: vector.add(mid-top, (0, head-radius)),
+      south: vector.add(mid-top, (0, -height - head-radius)),
+      center: center-pt,
+      mid: center-pt,
+      head-center: mid-top,
+      head-south: vector.add(mid-top, (0, -head-radius)),
+      south-west: bottom-left,
+      south-east: bottom-right,
+      north-west: pt,
+      default: center-pt,
+      north-east: top-right,
+      start: pt,
+      end: bottom-right,
+    )
+    for (name, pos) in anchors {
+      _cetz-anchor(name, pos)
+    }
+  })
+}


### PR DESCRIPTION
I aim to replace powerpoint with `cetz` + `polylux`, but the lack of shapes to insert is a critical roadblock. It would be wonderful if these existed as additional `decorations`. However, the internals of `cetz` are a bit tough to grasp, so I don't know whether I'm on the right track. I'm looking for (1) whether this idea is appreciated as belonging in the cetz library, and (2) whether the implementation + api is satisfactory. If the community/maintainers are receptive, I can proceed with adding additional shapes.

MWE:
```typst
#import "@preview/cetz:0.1.2"
#import cetz.draw: *
#import cetz.decorations: *

#cetz.canvas({
  cylinder(
    (0,0), 5, 3,
    fill: blue,
    top-fill: blue.lighten(40%),
    name: "cylinder",
    anchor: "right",
    content: align(center + horizon)[Hello, World!]
  )
  for-each-anchor("cylinder", anchor => {
    content((), angle: -45deg, box(fill: rgb("#fff6"), inset: 0.1em, text(size: 8pt, anchor)))
  })
})
```
![image](https://github.com/johannes-wolf/cetz/assets/23620506/bab6ef3b-16b9-44a8-80bb-3a9e1f944a0a)

## Roadmap
I would implement a subset of powerpoint shapes and use that behavior to infer default control points etc:
![image](https://github.com/johannes-wolf/cetz/assets/23620506/be831611-bc65-49cc-bf9b-8656e2688691)

## Questions
- Should there be `flowchart`, `block arrows`, etc. submodules, or should all live under the `decorations` namespace?
- Should `content` be a parameter, or should the user add this as an additional `cetz` element? I initially included `content` since it allows the cylinder itself to appropriately add margin, center the material, and so on. But this is not a common pattern for other `cetz` elements, so I am curious on a better implementation plan.
  - I also use content within a shape more often than not in ppt, so this would be an extremely common use case as I see it.
- Are there cases where deviating from powerpoint control points / sizing defaults is preferred? (This question may be easier to answer as the PR is developed)
- Should the PR be split up? It would be undesirable to require waiting until the whole library is full before making the shapes accessible
- Is this functionality more suited to a separate `typst` package than a cetz contribution?

Thanks for the lovely typst package! It was easier than to get started with the contribution. The hard part is making sure the shapes API is robust against everything cetz is designed to support... 