### PR TITLE
feat: add `arc-2pt` to draw an arc between two points

### DIFF
--- a/src/styles.typ
+++ b/src/styles.typ
@@ -96,7 +96,8 @@
     mark: auto,
     stroke: auto,
     fill: auto,
-    radius: auto
+    radius: auto,
+    rotation: 0deg,
   ),
   content: (
     padding: auto,


### PR DESCRIPTION
Based on [this Discord discussion](https://discord.com/channels/1054443721975922748/1088371919725793360/1187287465111863357), this PR adds a new draw function called `arc-2pt` which draws an arc given a start and end point, the radius, and two boolean flags. This is the arc parameterization that SVG uses, and they describe how to convert between this and the "center parameterization" which the `arc` function uses [here](https://www.w3.org/TR/SVG/implnote.html#ArcConversionEndpointToCenter).

As part of the PR I also added a new `rotation` style to the normal `arc` to define an angle to rotate the ellipse by before calculating the arc.

## Things left to do:
- [ ] fix compass anchors on arcs with rotation (i'm not sure where exactly they even should be)
- [ ] add docs for `arc-2pt`
- [ ] test compatibility with z axis
- [ ] fix current position after rotated arcs
- [ ] maybe move some of the `arc-2pt` args to a new style root?
- [ ] automatic radius correction as described [here](https://www.w3.org/TR/SVG/implnote.html#ArcCorrectionOutOfRangeRadii)

---

Before I can finish these things I would like to hear you opinions and insights on them, and maybe also have you review the current changes. Also with the anchors I'm not too confident in myself to manage fixing that, so if you could potentially do so I would be super grateful.

## Example

```typ
arc-2pt((), (rel: (1, 0)), 1)
arc-2pt((), (rel: (1, 0)), 1, large-arc: true)
arc-2pt((), (rel: (1, 0)), 1, sweep: true)
arc-2pt((), (rel: (1, 0)), 1, sweep: true, large-arc: true)
arc-2pt((), (rel: (1, 0)), (1, 1.5), large-arc: true, rotation: 45deg)
```
![image](https://github.com/johannes-wolf/cetz/assets/35602040/575b9840-e702-4bf8-b0ed-d82a378beb68)
