### PR TITLE
Make 2D alignment great again

### DIFF
--- a/src/draw/transformations.typ
+++ b/src/draw/transformations.typ
@@ -239,7 +239,7 @@
 /// circle((5,5))
 /// ```)
 ///
-/// - from (coordinate): Bottom-Left corner coordinate
+/// - from (coordinate): Bottom left corner coordinate
 /// - to (coordinate): Top right corner coordinate
 /// - bounds (vector): Viewport bounds vector that describes the inner width,
 ///   height and depth of the viewport


### PR DESCRIPTION
Fixes one inconsistency since #409.

Used `\rg -i '(bottom|top|left|right)[- ](bottom|top|left|right)'` again.