### PR TITLE
double import path-util necessary?

### DIFF
--- a/src/drawable.typ
+++ b/src/drawable.typ
@@ -1,4 +1,3 @@
-#import "path-util.typ"
 #import "vector.typ"
 #import "util.typ"
 #import "path-util.typ"


### PR DESCRIPTION
I see this file had a double import, I don't see why it is necessary