### PR TITLE
Validate Element Names

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -19,6 +19,7 @@ package called `cetz-plot`.
   transformations, without having to scope children under a group name.
 - The center anchor of `content()` with two coordinates got fixed when using
   negative cordinates.
+- Element names are now checked to not contain a "." character.
 
 ## Draw
 - Added `floating` function for drawing elements without affecting bounding boxes.

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -95,29 +95,25 @@
 
       place(top + left, float: false, if drawable.type == "path" {
         let vertices = ()
-        for s in drawable.segments {
-          let type = s.at(0)
-          let coordinates = s.slice(1).map(c => {
-            return (
-              (c.at(0) - bounds.low.at(0) - x) * length,
-              (c.at(1) - bounds.low.at(1) - y) * length,
-            )
+        for ((kind, ..pts)) in drawable.segments {
+          pts = pts.map(c => {
+            ((c.at(0) - bounds.low.at(0) - x) * length,
+             (c.at(1) - bounds.low.at(1) - y) * length)
           })
           assert(
-            type in ("line", "cubic"),
-            message: "Path segments must be of type line, cubic",
-          )
+            kind in ("line", "cubic"),
+            message: "Path segments must be of type line, cubic")
 
-          if type == "cubic" {
-            let a = coordinates.at(0)
-            let b = coordinates.at(1)
-            let ctrla = relative(a, coordinates.at(2))
-            let ctrlb = relative(b, coordinates.at(3))
+          if kind == "cubic" {
+            let a = pts.at(0)
+            let b = pts.at(1)
+            let ctrla = relative(a, pts.at(2))
+            let ctrlb = relative(b, pts.at(3))
 
             vertices.push((a, (0pt, 0pt), ctrla))
             vertices.push((b, ctrlb, (0pt, 0pt)))
           } else {
-            vertices += coordinates
+            vertices += pts
           }
         }
         if type(drawable.stroke) == dictionary and "thickness" in drawable.stroke and type(drawable.stroke.thickness) != typst-length {

--- a/src/process.typ
+++ b/src/process.typ
@@ -28,10 +28,19 @@
       }
     }
   }
-  if "name" in element and type(element.name) == "string" and "anchors" in element {
-    ctx.nodes.insert(element.name, element)
-    if ctx.groups.len() > 0 {
-      ctx.groups.last().push(element.name)
+
+  let name = element.at("name", default: none)
+  if name != none {
+    assert.eq(type(name), str,
+      message: "Element name must be a string")
+    assert(not name.contains("."),
+      message: "Invalid name for element '" + element.name + "'; name must not contain '.'")
+
+    if "anchors" in element {
+      ctx.nodes.insert(name, element)
+      if ctx.groups.len() > 0 {
+        ctx.groups.last().push(name)
+      }
     }
   }
 


### PR DESCRIPTION
- Process: Check that element names do not contain '.'
- Canvas: We use `kind` everywhere else as it does not shadow Typst's `type` function + unpacking the array