### PR TITLE
doc: Center text on line in content shape example

### DIFF
--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -705,7 +705,7 @@
 /// ```typc example
 /// line((0, 0), (3, 1), name: "line")
 /// content(
-///   ("line.start", 0.5, "line.end"),
+///   ("line.start", 50%, "line.end"),
 ///   angle: "line.end",
 ///   padding: .1,
 ///   anchor: "south", 


### PR DESCRIPTION
It took me a while to figure out why the text in the `content` example

```typst
line((0, 0), (3, 1), name: "line")
content(
  ("line.start", 0.5, "line.end"),
  angle: "line.end",
  padding: .1,
  anchor: "south",
  [Text on a line]
)
```

was not centered above the line. I suppose centering is a very common use case (maybe even intended in the example?), so I'd suggest using `50%` here to save folks some time figuring out that 0.5 is not a percentage but an absolute length :slightly_smiling_face: