### PR TITLE
docs: Add mark `anchor` documentation

### DIFF
--- a/docs/basics/marks.mdx
+++ b/docs/basics/marks.mdx
@@ -118,6 +118,10 @@ line(..c)
   Like `pos` but it advances the position of the mark instead of overriding it.
 </Parameter>
 
+<Parameter name="anchor" types="str" default_value="tip">
+  Anchor to position the mark at. Can be one of `base`, `center` or `tip`.
+</Parameter>
+
 <Parameter name="slant" types="ratio" default_value="0%">
   How much to slant the mark relative to the axis of the arrow. 0% means no
   slant 100% slants at 45 degrees.


### PR DESCRIPTION
Add missing documentation for the mark `anchor` attribute.