### PR TITLE
Fix docs for `draw-edge` function in `tree` library

### DIFF
--- a/src/lib/tree.typ
+++ b/src/lib/tree.typ
@@ -46,7 +46,7 @@
 ///
 /// - root (array): A nested array of content that describes the structure the tree should take. Example: `([root], [child 1], ([child 2], [grandchild 1]))`
 /// - draw-node (auto,function): The function to call to draw a node. The function will be passed two positional arguments, the node to draw and the node's parent, and is expected to return elements (`(node, parent-node) => elements`). The node's position is accessible through the "center" anchor or by using the previous position coordinate `()`. If `auto` is given, just the node's value will be drawn as content. The following predefined styles can be used:
-/// - draw-edge (none,auto,function): The function to call draw an edge between two nodes. The function will be passed the name of the starting node, the name of the ending node, and the end node and is expected to return elements (`(source-name, target-name, target-node) => elements`). If `auto` is given, a straight line will be drawn between nodes.
+/// - draw-edge (none,auto,function): The function to call draw an edge between two nodes. The function will be passed the name of the starting node, the name of the ending node, the start node, the end node, and is expected to return elements (`(source-name, target-name, parent-node, child-node) => elements`). If `auto` is given, a straight line will be drawn between nodes.
 /// - direction (str): A string describing the direction the tree should grow in ("up", "down", "left", "right")
 /// - parent-position (str): Positioning of parent nodes (begin, center, end)
 /// - grow (float): Depth grow factor


### PR DESCRIPTION
Fix the signature of `draw-edge` function argument in the `tree` library to correctly specify that it actually accepts 4 arguments.