### PR TITLE
lib: Remove plot stub

### DIFF
--- a/src/lib.typ
+++ b/src/lib.typ
@@ -21,6 +21,3 @@
 #import "lib/angle.typ"
 #import "lib/tree.typ"
 #import "lib/decorations.typ"
-
-// Stubs
-#import "lib/plot-stub.typ" as plot

--- a/src/lib/plot-stub.typ
+++ b/src/lib/plot-stub.typ
@@ -1,2 +1,0 @@
-// DEPRECATED TODO: Remove this after 0.3.0
-#let plot(..args) = panic("cetz plotting library has been moved to its own package, cetz-plot")


### PR DESCRIPTION
It can result in overriding cetz-plots `plot` function, if imported after `cetz-plot`.
