### PR TITLE
line: Add default anchor for closed lines

### DIFF
--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -566,6 +566,7 @@
         }
       },
       if close != none { ("centroid",) } else { () },
+      default: if close != none { "centroid" },
       name: name,
       transform: ctx.transform,
       path-anchors: true,


### PR DESCRIPTION
Add a default anchor for closed lines. This allows using intersection syntax (`line`) with
polygons drawn using `line()`.

Fixes #776.