### PR TITLE
Replace the URL in the submodule with read-only URL

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "common"]
 	path = common
-	url = git@github.com:cetz-package/common.git
+	url = https://github.com/cetz-package/common.git


### PR DESCRIPTION
Hi, I am currently trying to upstream my Typst package support for Nixpkgs, and wrapping cetz into Nixpkgs is part of that PR. However, I failed to bump cetz from v0.2.2 to v0.3.1 because the latter uses a read-write URL for its submodule, namely `common`. This blocks nix source fetcher to clone the source from its submodule, as it requires the access capability.

This RP addresses this issue by replacing the submodule URL with read-only URL, which should be useful in general for automatic package builders.