### PR TITLE
fix typo coordinate-systems.mdx

### DIFF
--- a/docs/basics/coordinate-systems.mdx
+++ b/docs/basics/coordinate-systems.mdx
@@ -252,7 +252,7 @@ Can be used to find the intersection of a vertical line going through a point $p
   The coordinate through which the vertical line passes.
 </Parameter>
 
-You can use the implicit syntax of `(horizontal, "-|", vertical)` or `(vertical, "|-", horizontal)`.
+You can use the implicit syntax of `(horizontal, "|-", vertical)` or `(vertical, "-|", horizontal)`.
 
 ```typc example
 set-style(content: (padding: .05))


### PR DESCRIPTION
The syntax explanation is mixed up. You can confirm that your self by comparing it to the given example right below the change.