### PR TITLE
Fix tree node order

### DIFF
--- a/src/lib/tree.typ
+++ b/src/lib/tree.typ
@@ -165,9 +165,9 @@
     } else if direction == "north" {
       return (node.x, node.y)
     } else if direction == "west" {
-      return (-node.y, node.x)
+      return (-node.y, -node.x)
     } else if direction == "east" {
-      return (node.y, node.x)
+      return (node.y, -node.x)
     } else {
       panic(message: "Invalid tree direction.")
     }


### PR DESCRIPTION
```typ
#import "@preview/cetz:0.3.1"

#set page(width: auto, height: auto)

#let data = ([Groceries], ([Fruits], [Apples], [Bananas], [Oranges]), ([Vegetables], [Potatoes], [Spinach], [Tomatoes]))

#cetz.canvas({
  import cetz.draw: *

  cetz.tree.tree( 
    data,
    direction: "right",
    draw-node: (node, ..) => {
      content((), [#node.content], anchor: "west")
    },
    draw-edge: (from, to, ..) => {
      let (a, b) = (from + ".east", to + ".west")
      line((a, .4, b), (b, .4, a), stroke: red)
    }, 
    grow: 3,
  )
})
```

| Before | After |
|--------|--------|
| ![Before](https://github.com/user-attachments/assets/841a6228-80aa-4949-9c70-d6f250b9e981) | ![After](https://github.com/user-attachments/assets/b9fe6715-356a-4cab-a5a9-779e5ace251e) | 