### PR TITLE
Add background field to canvas context for background-aware drawing

### DIFF
--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -37,6 +37,7 @@
     version: version.version,
     length: length,
     debug: debug,
+    background: background,
     // Previous element position & bbox
     prev: (pt: (0, 0, 0)),
     style: styles.default,


### PR DESCRIPTION
When drawing inside a canvas, having access to the background color is crucial for background-aware drawing. By adding `background` field to the canvas`ctx`, we can retrieve the current background color using the `get-ctx` function.

This improves visual consistency, especially in dynamic themes like dark mode. The following example demonstrates the impact ([Typst App Link](https://typst.app/project/rqinfUGm5flVRTuE0PQJI4))
- The upper diagram utilizes the background color for adaptive drawing.
- The lower diagram lacks background color infomation, resulting in a much poorer appearance in dark theme.

![cetz_canvas_background](https://github.com/user-attachments/assets/064db247-4a50-4db7-9c47-4584c0f7cdc8)
