### PR TITLE
Small `aabb` rewrite

### DIFF
--- a/src/aabb.typ
+++ b/src/aabb.typ
@@ -6,29 +6,29 @@
 /// - init (aabb): Initial aabb
 /// -> aabb
 #let aabb(pts, init: none) = {
-  let bounds = init
-
   if type(pts) == array {
-    for (i, pt) in pts.enumerate() {
-      if bounds == none and i == 0 {
-        bounds = (low: pt, high: pt)
-      } else {
-        assert(type(pt) == array and pt.len() == 3, message: repr(init) + repr(pts))
-        let (x, y, z) = pt
+    let bounds = if init == none and 0 < pts.len() {
+      let pt = pts.at(0)
+      (low: pt, high: pt)
+    } else {
+      init
+    }
+    for pt in pts {
+      assert(type(pt) == array and pt.len() == 3, message: repr(init) + repr(pts))
+      let (x, y, z) = pt
 
-        let (lo-x, lo-y, lo-z) = bounds.low
-        bounds.low = (calc.min(lo-x, x), calc.min(lo-y, y), calc.min(lo-z, z))
+      let (lo-x, lo-y, lo-z) = bounds.low
+      bounds.low = (calc.min(lo-x, x), calc.min(lo-y, y), calc.min(lo-z, z))
 
-        let (hi-x, hi-y, hi-z) = bounds.high
-        bounds.high = (calc.max(hi-x, x), calc.max(hi-y, y), calc.max(hi-z, z))
-      }
+      let (hi-x, hi-y, hi-z) = bounds.high
+      bounds.high = (calc.max(hi-x, x), calc.max(hi-y, y), calc.max(hi-z, z))
     }
     return bounds
   } else if type(pts) == dictionary {
     if init == none {
       return pts
     } else {
-      return aabb((pts.low, pts.high,), init: bounds)
+      return aabb((pts.low, pts.high,), init: init)
     }
   }
 


### PR DESCRIPTION
While searching for performance improvements, I tried to rewrite `aabb`. I have not managed to make a dent in the running time, but this PR suggest a small change to make the code slightly more readable. Now the init logic is moved outside the loop, which allows the `enumerate` to be removed. Also, it makes the logic more clear. It's now clearer that there might be a bug, because the `init == none and pts.len() == 0` case seems to not be handled (in the old and new code, it would just default to `init`, but that was `none` so the `bounds.low` line will then crash.)

Since the diff is so confusing, this was the code before this change:
```typ
#let aabb(pts, init: none) = {
  let bounds = init

  if type(pts) == array {
    for (i, pt) in pts.enumerate() {
      if bounds == none and i == 0 {
        bounds = (low: pt, high: pt)
      } else {
        assert(type(pt) == array and pt.len() == 3, message: repr(init) + repr(pts))
        let (x, y, z) = pt

        let (lo-x, lo-y, lo-z) = bounds.low
        bounds.low = (calc.min(lo-x, x), calc.min(lo-y, y), calc.min(lo-z, z))

        let (hi-x, hi-y, hi-z) = bounds.high
        bounds.high = (calc.max(hi-x, x), calc.max(hi-y, y), calc.max(hi-z, z))
      }
    }
    return bounds
  } else if type(pts) == dictionary {
    if init == none {
      return pts
    } else {
      return aabb((pts.low, pts.high,), init: bounds)
    }
  }

  panic("Expected array of vectors or bbox dictionary, got: " + repr(pts))
}
```

After:

```typ
#let aabb(pts, init: none) = {
  if type(pts) == array {
    let bounds = if init == none and 0 < pts.len() {
      let pt = pts.at(0)
      (low: pt, high: pt)
    } else {
      init
    }
    for pt in pts {
      assert(type(pt) == array and pt.len() == 3, message: repr(init) + repr(pts))
      let (x, y, z) = pt

      let (lo-x, lo-y, lo-z) = bounds.low
      bounds.low = (calc.min(lo-x, x), calc.min(lo-y, y), calc.min(lo-z, z))

      let (hi-x, hi-y, hi-z) = bounds.high
      bounds.high = (calc.max(hi-x, x), calc.max(hi-y, y), calc.max(hi-z, z))
    }
    return bounds
  } else if type(pts) == dictionary {
    if init == none {
      return pts
    } else {
      return aabb((pts.low, pts.high,), init: init)
    }
  }

  panic("Expected array of vectors or bbox dictionary, got: " + repr(pts))
}
```