### PR TITLE
Add fast path for rect without radius

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 docs/_generated
+tmp*

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1169,7 +1169,26 @@
       let (north-west: nw, north-east: ne,
            south-west: sw, south-east: se) = util.as-corner-radius-dict(ctx, style.radius, size)
 
-      let drawables = {
+      let no-radius = style.radius == none or style.radius == 0
+      let drawables = if no-radius {
+        let segments = ()
+        // Four corner points for a non-rounded rectangle:
+        //
+        //   p0-----p1
+        //   |       |
+        //   |       |
+        //   p3-----p2
+        //
+        let p0 = (x1, y2, z1)
+        let p1 = (x2, y2, z1)
+        let p2 = (x2, y1, z1)
+        let p3 = (x1, y1, z1)
+        segments += (path-util.line-segment((p0, p1)),)
+        segments += (path-util.line-segment((p1, p2)),)
+        segments += (path-util.line-segment((p2, p3)),)
+        segments += (path-util.line-segment((p3, p0)),)
+        drawable.path(segments, fill: style.fill, stroke: style.stroke, close: false)
+      } else {
         let z = z1
 
         // Compute two corner points offset by radius from origin pt.

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1174,20 +1174,20 @@
         let segments = ()
         // Four corner points for a non-rounded rectangle:
         //
-        //   p0-----p1
+        //   p0-----p3
         //   |       |
         //   |       |
-        //   p3-----p2
+        //   p1-----p2
         //
         let p0 = (x1, y2, z1)
-        let p1 = (x2, y2, z1)
+        let p1 = (x1, y1, z1)
         let p2 = (x2, y1, z1)
-        let p3 = (x1, y1, z1)
+        let p3 = (x2, y2, z1)
         segments += (path-util.line-segment((p0, p1)),)
         segments += (path-util.line-segment((p1, p2)),)
         segments += (path-util.line-segment((p2, p3)),)
         segments += (path-util.line-segment((p3, p0)),)
-        drawable.path(segments, fill: style.fill, stroke: style.stroke, close: false)
+        drawable.path(segments, fill: style.fill, stroke: style.stroke, close: true)
       } else {
         let z = z1
 


### PR DESCRIPTION
This PR suggests to add a fast path for rectangles without a radius. When benchmarking with 100 and 500 points, it is about 5% faster on my system. My test document was

```typ
#import "/src/lib.typ": *

#set page(width: auto, height: auto)

#let pts = array.range(500).map(x => (x, x))

#canvas({
  import draw: *

  for pt in pts {
    rect(pt, (rel: (0.5, 0.5), to: pt), fill: blue, stroke: none)
  }
})
```
and my benchmark command was
```sh
$ hyperfine --warmup=1 --runs=10 "typst c --ppi=10 --format=png tmp.typ"
```
which generates a 106 KB 1986 x 1986 image.