### PR TITLE
Extract `dim-extrema` from `cubic-extrema`

### DIFF
--- a/src/bezier.typ
+++ b/src/bezier.typ
@@ -386,6 +386,37 @@
   }
 }
 
+// Compute roots of a single dimension (x, y, z) of the
+// curve by using the abc formula for finding roots of
+// the curves first derivative.
+#let _dim-extrema(a, b, c1, c2) = {
+  let f0 = calc.round(3*(c1 - a), digits: 8)
+  let f1 = calc.round(6*(c2 - 2*c1 + a), digits: 8)
+  let f2 = calc.round(3*(b - 3*c2 + 3*c1 - a), digits: 8)
+
+  if f1 == 0 and f2 == 0 {
+    return ()
+  }
+
+  // Linear function
+  if f2 == 0 {
+    return (-f0 / f1,)
+  }
+
+  // No real roots
+  let discriminant = f1*f1 - 4*f0*f2
+  if discriminant < 0 {
+    return ()
+  }
+
+  if discriminant == 0 {
+    return (-f1 / (2*f2),)
+  }
+  
+  return ((-f1 - calc.sqrt(discriminant)) / (2*f2),
+          (-f1 + calc.sqrt(discriminant)) / (2*f2))
+}
+
 /// Find cubic curve extrema by calculating the roots of the curve's first derivative. Returns an <Type>array</Type> of <Type>vector</Type> ordered by distance along the curve from the start to its end.
 /// - s (vector): Curve start
 /// - e (vector): Curve end
@@ -393,41 +424,10 @@
 /// - c2 (vector): Control point 2
 /// -> array
 #let cubic-extrema(s, e, c1, c2) = {
-  // Compute roots of a single dimension (x, y, z) of the
-  // curve by using the abc formula for finding roots of
-  // the curves first derivative.
-  let dim-extrema(a, b, c1, c2) = {
-    let f0 = calc.round(3*(c1 - a), digits: 8)
-    let f1 = calc.round(6*(c2 - 2*c1 + a), digits: 8)
-    let f2 = calc.round(3*(b - 3*c2 + 3*c1 - a), digits: 8)
-
-    if f1 == 0 and f2 == 0 {
-      return ()
-    }
-
-    // Linear function
-    if f2 == 0 {
-      return (-f0 / f1,)
-    }
-
-    // No real roots
-    let discriminant = f1*f1 - 4*f0*f2
-    if discriminant < 0 {
-      return ()
-    }
-
-    if discriminant == 0 {
-      return (-f1 / (2*f2),)
-    }
-    
-    return ((-f1 - calc.sqrt(discriminant)) / (2*f2),
-            (-f1 + calc.sqrt(discriminant)) / (2*f2))
-  }
-
   let pts = ()
   let dims = calc.max(s.len(), e.len())
   for dim in range(dims) {
-    let ts = dim-extrema(
+    let ts = _dim-extrema(
       s.at(dim, default: 0),
       e.at(dim, default: 0),
       c1.at(dim, default: 0),


### PR DESCRIPTION
It's quite a silly change, but I'm getting consistently 3%-4% better performance with

```typst
#import "/src/lib.typ": *

#set page(width: auto, height: auto)

#let pts = array.range(500).map(x => (x, x))

#canvas({
  import draw: *

  for pt in pts {
    circle(pt, fill: blue, stroke: none)
  }
})
```
and
```sh
$ hyperfine --warmup=1 --runs=10 "typst c --ppi=10 --format=png tmp.typ"
```

Are you in favor of rewrites like this? Or should I see whether this can be fixed in the Typst compiler? 

I personally would lean in favor of biting the bullet and rewriting these kinds of code because it sort of makes sense that defining a function at the module level once is faster than constantly defining a function as an inner function. Also, readability-wise having the function on the top level is easier to read in my opinion. But I don't have a very strong opinion on this.