### PR TITLE
Run `mul4x4-vec3` in wasm

### DIFF
--- a/cetz-core/src/lib.rs
+++ b/cetz-core/src/lib.rs
@@ -170,13 +170,13 @@ struct Mul4x4Vec3Args {
     w: f64,
 }
 
-fn mul4x4_vec3(mat: Vec<Point>, vec: Point, w: f64) -> Result<Point, String> {
+fn mul4x4_vec3(mat: &[Point], vec: &Point, w: f64) -> Result<Point, String> {
     assert!(vec.len() <= 4);
 
     let x = vec[0];
     let y = vec[1];
-    let z = vec.get(2).unwrap_or(&0.0);
-    let w = vec.get(3).unwrap_or(&w);
+    let z = vec.get(2).copied().unwrap_or(0.0);
+    let w = vec.get(3).copied().unwrap_or(w);
 
     let result = vec!(
         mat[0][0] * x + mat[0][1] * y + mat[0][2] * z + mat[0][3] * w,
@@ -189,6 +189,23 @@ fn mul4x4_vec3(mat: Vec<Point>, vec: Point, w: f64) -> Result<Point, String> {
 #[wasm_func]
 pub fn mul4x4_vec3_func(input: &[u8]) -> Result<Vec<u8>, String> {
     handle_cbor(input, |args: Mul4x4Vec3Args| {
-        mul4x4_vec3(args.mat, args.vec, args.w)
+        mul4x4_vec3(&args.mat, &args.vec, args.w)
+    })
+}
+
+#[derive(Deserialize)]
+struct Mul4x4VecsArgs {
+    mat: Vec<Point>,
+    vecs: Vec<Point>,
+}
+
+fn mul4x4_vecs(mat: &[Point], vecs: &[Point]) -> Result<Vec<Point>, String> {
+    vecs.iter().map(|vec| mul4x4_vec3(mat, vec, 1.0)).collect()
+}
+
+#[wasm_func]
+pub fn mul4x4_vecs_func(input: &[u8]) -> Result<Vec<u8>, String> {
+    handle_cbor(input, |args: Mul4x4VecsArgs| {
+        mul4x4_vecs(&args.mat, &args.vecs)
     })
 }

--- a/cetz-core/src/lib.rs
+++ b/cetz-core/src/lib.rs
@@ -162,3 +162,33 @@ pub fn aabb_func(input: &[u8]) -> Result<Vec<u8>, String> {
         Err(e) => Err(e.to_string()),
     }
 }
+
+#[derive(Deserialize)]
+struct Mul4x4Vec3Args {
+    mat: Vec<Point>,
+    vec: Point,
+    w: f64,
+}
+
+fn mul4x4_vec3(mat: Vec<Point>, vec: Point, w: f64) -> Result<Point, String> {
+    assert!(vec.len() <= 4);
+
+    let x = vec[0];
+    let y = vec[1];
+    let z = vec.get(2).unwrap_or(&0.0);
+    let w = vec.get(3).unwrap_or(&w);
+
+    let result = vec!(
+        mat[0][0] * x + mat[0][1] * y + mat[0][2] * z + mat[0][3] * w,
+        mat[1][0] * x + mat[1][1] * y + mat[1][2] * z + mat[1][3] * w,
+        mat[2][0] * x + mat[2][1] * y + mat[2][2] * z + mat[2][3] * w,
+    );
+    Ok(result)
+}
+
+#[wasm_func]
+pub fn mul4x4_vec3_func(input: &[u8]) -> Result<Vec<u8>, String> {
+    handle_cbor(input, |args: Mul4x4Vec3Args| {
+        mul4x4_vec3(args.mat, args.vec, args.w)
+    })
+}

--- a/src/aabb.typ
+++ b/src/aabb.typ
@@ -5,7 +5,7 @@
 ///
 /// - pts (array): List of <Type>vector</Type>s.
 /// - init (aabb): Initial aabb
-/// -> aabb
+/// -> (Vec<f64>, Vec<f64>)
 #let aabb(pts, init: none) = {
   let args = (pts: pts, init: init)
   let encoded = cbor.encode(args)

--- a/src/anchor.typ
+++ b/src/anchor.typ
@@ -177,9 +177,6 @@
       } else if type(anchor) == angle {
         assert(border-anchors, message: strfmt("Element '{}' does not support border anchors.", name))
         out = border(callback("center"), ..radii, path, anchor)
-        for o in out {
-          assert(type(o) == float, message: "Border anchor must return floats")
-        }
         assert(out != none, message: strfmt("Element '{}' does not have a border for anchor '{}'.", name, anchor))
       } else {
         panic(strfmt("Unknown anchor '{}' for element '{}'", repr(anchor), name))

--- a/src/anchor.typ
+++ b/src/anchor.typ
@@ -34,7 +34,7 @@
 /// - y-dist (number): The furthest distance the test line should go in the y direction.
 /// - drawables (drawables): Drawables to test for an intersection against. Ideally should be of type path but all others are ignored.
 /// - angle (angle): The angle to check for a border anchor at.
-/// -> vector,none
+/// -> vector<float>,none
 #let border(center, x-dist, y-dist, drawables, angle) = {
   x-dist += util.float-epsilon
   y-dist += util.float-epsilon
@@ -48,7 +48,7 @@
     (
       center.at(0) + x-dist * calc.cos(angle),
       center.at(1) + y-dist * calc.sin(angle),
-      center.at(2),
+      util.promote-float(center.at(2)),
     )
   )
 
@@ -177,6 +177,9 @@
       } else if type(anchor) == angle {
         assert(border-anchors, message: strfmt("Element '{}' does not support border anchors.", name))
         out = border(callback("center"), ..radii, path, anchor)
+        for o in out {
+          assert(type(o) == float, message: "Border anchor must return floats")
+        }
         assert(out != none, message: strfmt("Element '{}' does not have a border for anchor '{}'.", name, anchor))
       } else {
         panic(strfmt("Unknown anchor '{}' for element '{}'", repr(anchor), name))

--- a/src/canvas.typ
+++ b/src/canvas.typ
@@ -39,16 +39,16 @@
     debug: debug,
     background: background,
     // Previous element position & bbox
-    prev: (pt: (0, 0, 0)),
+    prev: (pt: (0., 0., 0.)),
     style: styles.default,
     // Current transformation matrix, a rhs coordinate system
     // where z is sheared by a half x and y.
     //   +x = right, +y = up, +z = 1/2 (left + down)
     transform:
-      ((1, 0,-.5, 0),
-       (0,-1,+.5, 0),
-       (0, 0,  0, 0), // FIXME: This should not be zero for Z! Changing it destroys mark & decorations in 3D space.
-       (0, 0, .0, 1)),
+      ((1., 0.,-.5, 0.),
+       (0.,-1.,+.5, 0.),
+       (0., 0., 0., 0.), // FIXME: This should not be zero for Z! Changing it destroys mark & decorations in 3D space.
+       (0., 0., 0., 1.)),
     // Nodes, stores anchors and paths
     nodes: (:),
     // Group stack

--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -53,6 +53,7 @@
     message: "circle expects one or two points, got " + repr(points))
   assert(points.len() != 2 or "radius" not in style,
     message: "unexpected radius for circle constructed by two points")
+  let points = points.map(util.promote-float)
 
   (ctx => {
     let (center, outer) = if points.len() == 1 {
@@ -90,7 +91,7 @@
       transform: ctx.transform,
       border-anchors: true,
       path-anchors: true,
-      radii: (rx*2, ry*2),
+      radii: (rx*2., ry*2.),
       path: drawables,
     )
 
@@ -132,6 +133,9 @@
 #let circle-through(a, b, c, name: none, anchor: none, ..style) = {
   assert.eq(style.pos(), (), message: "Unexpected positional arguments: " + repr(style.pos()))
   style = style.named()
+  let a = util.promote-float(a)
+  let b = util.promote-float(b)
+  let c = util.promote-float(c)
 
   (a, b, c).map(coordinate.resolve-system)
 
@@ -145,7 +149,7 @@
     let r = vector.dist(a, (cx, cy))
 
     let drawables = drawable.ellipse(
-      cx, cy, 0,
+      cx, cy, 0.,
       r, r,
       fill: style.fill,
       stroke: style.stroke
@@ -522,6 +526,7 @@
   let style = pts-style.named()
 
   assert(pts.len() >= 2, message: "Line must have a minimum of two points")
+  let pts = pts.map(util.promote-float)
 
   // Coordinate check
   let pts-system = pts.map(coordinate.resolve-system)

--- a/src/draw/transformations.typ
+++ b/src/draw/transformations.typ
@@ -203,7 +203,7 @@
       let (ctx, c) = coordinate.resolve(ctx, origin)
       let (x, y, z) = vector.sub(
         util.apply-transform(ctx.transform, c),
-        util.apply-transform(ctx.transform, (0, 0, 0)),
+        util.apply-transform(ctx.transform, (0., 0., 0.)),
       )
       ctx.transform = matrix.mul-mat(matrix.transform-translate(x, y, z), ctx.transform)
       return (ctx: ctx)

--- a/src/drawable.typ
+++ b/src/drawable.typ
@@ -22,9 +22,6 @@
       message: "Expected drawable, got array: " + repr(drawable))
     if drawable.type == "path" {
       drawable.segments = drawable.segments.map(((origin, closed, segments)) => {
-        for x in origin {
-          assert(type(x) == float, message: "Origin must contain only floats: " + repr(origin))
-        }
         origin = util.apply-transform(transform, origin)
         if type(segments.first()) != array {
           panic(origin, segments)

--- a/src/drawable.typ
+++ b/src/drawable.typ
@@ -22,6 +22,9 @@
       message: "Expected drawable, got array: " + repr(drawable))
     if drawable.type == "path" {
       drawable.segments = drawable.segments.map(((origin, closed, segments)) => {
+        for x in origin {
+          assert(type(x) == float, message: "Origin must contain only floats: " + repr(origin))
+        }
         origin = util.apply-transform(transform, origin)
         if type(segments.first()) != array {
           panic(origin, segments)

--- a/src/intersection.typ
+++ b/src/intersection.typ
@@ -57,7 +57,7 @@
 /// - la (vector): Line start
 /// - lb (vector): Line end
 /// - path (drawable): The path.
-/// -> array
+/// -> array<array<float>>
 #let line-path(la, lb, path) = {
   let pts = ()
 
@@ -85,6 +85,7 @@
     }
   }
 
+  pts = pts.map(pt => pt.map(util.promote-float))
   return pts
 }
 

--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -275,9 +275,6 @@
 }
 
 #let mul4x4-vec3(mat, vec, w: 1.0) = {
-  // let vec = vec.map(x => if type(x) == int {float(x)} else {x})
-  let mat = mat.map(row => row.map(x => if type(x) == int {float(x)} else {x}))
-
   let encoded = cbor.encode((mat: mat, vec: vec, w: w))
   let result = cbor(cetz-core.mul4x4_vec3_func(encoded))
   return result

--- a/src/matrix.typ
+++ b/src/matrix.typ
@@ -1,4 +1,5 @@
 #import "vector.typ"
+#let cetz-core = plugin("../cetz-core/cetz_core.wasm")
 
 // Global rounding precision
 #let precision = 8
@@ -258,7 +259,7 @@
 /// - vec (vector): The vector to multiply
 /// - w (float): The default value for the fourth element of the vector if it is three dimensional.
 /// -> vector
-#let mul4x4-vec3(mat, vec, w: 1) = {
+#let mul4x4-vec3-2(mat, vec, w: 1) = {
   assert(vec.len() <= 4)
 
   let x = vec.at(0)
@@ -271,6 +272,15 @@
     a1 * x + a2 * y + a3 * z + a4 * w,
     b1 * x + b2 * y + b3 * z + b4 * w,
     c1 * x + c2 * y + c3 * z + c4 * w)
+}
+
+#let mul4x4-vec3(mat, vec, w: 1.0) = {
+  // let vec = vec.map(x => if type(x) == int {float(x)} else {x})
+  let mat = mat.map(row => row.map(x => if type(x) == int {float(x)} else {x}))
+
+  let encoded = cbor.encode((mat: mat, vec: vec, w: w))
+  let result = cbor(cetz-core.mul4x4_vec3_func(encoded))
+  return result
 }
 
 // Multiply matrix with vector

--- a/src/process.typ
+++ b/src/process.typ
@@ -52,9 +52,9 @@
   if ctx.debug and bounds != none {
     element.drawables.push(drawable.path(
       ((bounds.low, true, (
-        ("l", (bounds.high.at(0), bounds.low.at(1), 0)),
+        ("l", (bounds.high.at(0), bounds.low.at(1), 0.)),
         ("l", bounds.high),
-        ("l", (bounds.low.at(0), bounds.high.at(1), 0)))),),
+        ("l", (bounds.low.at(0), bounds.high.at(1), 0.)))),),
       stroke: red,
       close: true
     ))

--- a/src/sorting.typ
+++ b/src/sorting.typ
@@ -7,7 +7,8 @@
 /// - points (array): List of points to sort
 /// - reference (vec): Reference point
 /// -> List of points
-#let points-by-distance(ctx, points, reference: (0, 0, 0)) = {
+#let points-by-distance(ctx, points, reference: (0., 0., 0.)) = {
+  let reference = reference.map(util.promote-float)
   let reference = util.apply-transform(ctx.transform, reference)
   return points.sorted(key: pt => {
     vector.dist(pt, reference)
@@ -21,7 +22,8 @@
 /// - points (array): List of points to sort
 /// - reference (vec): Reference point
 /// -> List of points
-#let points-by-angle(ctx, points, reference: (0, 0, 0)) = {
+#let points-by-angle(ctx, points, reference: (0., 0., 0.)) = {
+  let reference = reference.map(util.promote-float)
   let (rx, ry, ..) = util.apply-transform(ctx.transform, reference)
   return points.sorted(key: ((px, py, ..)) => {
     360deg - calc.atan2(rx - px, ry - py)

--- a/src/util.typ
+++ b/src/util.typ
@@ -8,6 +8,13 @@
 /// Constant to be used as float rounding error
 #let float-epsilon = 0.000001
 
+/// Promotes an integer to a float.
+/// - x (int,float): The value to promote.
+/// -> float
+#let promote-float(x) = {
+  return if type(x) == int {float(x)} else {x}
+}
+
 /// Multiplies vectors by a transformation matrix. If multiple vectors are given they are returned as an array, if only one vector is given only one will be returned, if a dictionary is given they will be returned in the dictionary with the same keys.
 ///
 /// - transform (matrix,function): The $4 \times 4$ transformation matrix or a function that accepts and returns a vector.
@@ -25,6 +32,11 @@
       vecs.insert(k, t(vec))
     }
   } else {
+    for vec in vecs.pos() {
+      for x in vec {
+        assert(type(x) == float, message: "Vector must contain only floats: " + repr(vec))
+      }
+    }
     vecs = vecs.pos().map(t)
     if vecs.len() == 1 {
       return vecs.first()


### PR DESCRIPTION
As a continuation of https://github.com/cetz-package/cetz/pull/850, this is an experiment which probably will not be merged and that's fine.

I noticed that when running a [benchmark](https://github.com/cetz-package/cetz/pull/850#issuecomment-2936119941) that a lot of time is spent inside `mul4x4-vec3`. So I tried to move that in Wasm to see whether it's faster. Unfortunately, it isn't.

It does pass the tests, but it is slower. 550 ms versus 500 ms (+10%). My guess is that converting (de)serializing vectors takes relatively too much time. I've tried to call wasm directly from inside `apply-transform` inside `drawable.typ`, but that also didn't speed things up. The bottom line is that (de)serializing the `segments` apparently takes too much time. I could try to go even higher and move even more in wasm, but it seems to me that the PR becomes a bit too big then.

In response to [a comment](https://github.com/cetz-package/cetz/pull/850#pullrequestreview-2893970888):

> Can we make the cbor decoding more relaxed about `int` vs `float`?

After working on the code for this PR a few hours, I do think promoting to float and using that internally should be an okay solution. CeTZ anyway promotes integers to floats all the time since it happens anytime basic arithmetic happens between int and float (e.g., 1 + 1.1 = 2.1 and 1 / 2 = 0.5).