### PR TITLE
Add Zap mention

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,5 +113,6 @@ To run all tests you can run the `just test` target. You need to have
 - [fletcher](https://github.com/Jollywatt/typst-fletcher) Package for drawing commutative diagrams and figures with arrows.
 - [chronos](https://git.kb28.ch/HEL/chronos) Package for drawing sequence diagrams.
 - [circuiteria](https://git.kb28.ch/HEL/circuiteria) Package for drawing circuits.
+- [zap](https://github.com/l0uisgrange/zap) Package for drawing standard electronic circuits.
 - [rivet](https://git.kb28.ch/HEL/rivet-typst) Package for drawing instruction / register diagrams.
 - [plotsy-3d](https://github.com/misskacie/plotsy-3d) Package for rendering 3D objects & plots.


### PR DESCRIPTION
Hi CeTZ maintainers 👋,

I'm happy to introduce you to Zap, a package to draw electronic circuits, currently available on Typst Universe (`v0.2.0`).

I think, as Zap uses a lot of CeTZ in the background, that it would be nice to add it on the CeTZ `README.md`.

Here's a suggestion, of course you are free to change the description.

Have a nice day ☀️!