### PR TITLE
Update a deprecated link to typst.app/docs

### DIFF
--- a/docs/basics/styling.mdx
+++ b/docs/basics/styling.mdx
@@ -22,7 +22,7 @@ You can style draw elements by passing the relevant named arguments to their dra
 </Parameter>
 <Parameter name="fill-rule" types="string" default_value="&quot;non-zero&quot;">
   How to fill self-intersecting paths. Can be "non-zero" or "even-odd".
-  [See Typst's path documentation for more details.](https://typst.app/docs/reference/visualize/path/#parameters-fill-rule)
+  [See Typst's path documentation for more details.](https://typst.app/docs/reference/visualize/curve/#parameters-fill-rule)
 </Parameter>
 
 


### PR DESCRIPTION
The `path` function is replaced by `curve`.
https://typst.app/docs/changelog/0.13.0/#visualization