### PR TITLE
docs: Add register-* Functions

### DIFF
--- a/docs/api/draw-functions/styling/register-mark.mdx
+++ b/docs/api/draw-functions/styling/register-mark.mdx
@@ -1,0 +1,5 @@
+import RegisterMark from "@site/cetz/docs/_generated/draw/styling/register-mark.mdx";
+
+# register-mark
+
+<RegisterMark />

--- a/docs/api/draw-functions/util/register-coordinate-resolver.mdx
+++ b/docs/api/draw-functions/util/register-coordinate-resolver.mdx
@@ -1,0 +1,5 @@
+import RegisterCoordinateResolver from "@site/cetz/docs/_generated/draw/util/register-coordinate-resolver.mdx";
+
+# register-coordinate-resolver
+
+<RegisterCoordinateResolver />


### PR DESCRIPTION
The `register-*` functions were missing from the docs.