### PR TITLE
docs: fix link from merge-path to hide

### DIFF
--- a/src/draw/shapes.typ
+++ b/src/draw/shapes.typ
@@ -1727,7 +1727,7 @@
 /// })
 /// ```
 ///
-/// Elements hidden via @@hide() are ignored.
+/// Elements hidden via [hide](../grouping/hide) are ignored.
 ///
 /// ## Anchors
 ///   **centroid**: Centroid of the _closed and non self-intersecting_ shape. Only exists if `close` is true.


### PR DESCRIPTION
The `@@` was quite striking; it was the only occurrence in the codebase.
Note that I did not yet set up a full-fledged environment (and I don't immediately see where and how the docs are built), so this fix is _untested_.

While looking at links throughout the docs, I also noticed that CeTZ functions are often unstyled, but sometimes `monospace`. Should I open another PR to move it all to monospace?