### PR TITLE
docs: Update coordinate length handling

### DIFF
--- a/docs/basics/canvas.md
+++ b/docs/basics/canvas.md
@@ -15,4 +15,4 @@ You can now call the draw functions within the body and they'll produce some gra
 
 The canvas does not have typical `width` and `height` parameters. Instead its size will grow and shrink to fit the drawn graphic.
 
-By default 1 [coordinate](/basics/coordinate-systems) unit is `1cm`, this can be changed by setting the `length` parameter. If a ratio is given, the length will be the size of the canvas' parent's width!
+By default 1 [coordinate](/basics/coordinate-systems) unit is `1cm`, this can be changed by setting the `length` parameter.

--- a/docs/basics/coordinate-systems.mdx
+++ b/docs/basics/coordinate-systems.mdx
@@ -7,6 +7,8 @@ import Type from "@site/src/components/Type";
 
 A <Type>coordinate</Type> is a position on the canvas on which the picture is drawn. They take the form of dictionaries and the following subsections define the key-value pairs for each system. Some systems have a more implicit form as an array of values and CeTZ attempts to infer the system based on the element types.
 
+By default 1 coordinate unit is `1cm`, this can be changed by setting the `length` parameter of [`canvas`](/api/internal/canvas).
+
 ## XYZ
 
 Defines a point `x` units right, `y` units upward and `z` units away.


### PR DESCRIPTION
I added the information that the length of coordinates can be changed with `canvas(length: )` that was already present on "Canvas" and added it to "Coordinate Systems" for better visibility.

Additionally, I removed the mention that the parameter also takes ratios, due to the Canvas API docs mentioning that this behaviour was deprecated