### PR TITLE
Bump default miter-limit for stealth marker.

### DIFF
--- a/src/mark-shapes.typ
+++ b/src/mark-shapes.typ
@@ -157,7 +157,7 @@
       ((0,0), (l, w / 2), (l - i, 0), (l, -w / 2))
     }
 
-    fast-line(..pts, stroke: style.stroke, fill: style.fill, close: true)
+    fast-line(..pts, stroke: (..style.stroke, miter-limit: 100), fill: style.fill, close: true)
     create-triangle-tip-and-base-anchor(style, (0, 0), (l - i, 0))
   },
   curved-stealth: (style) => {


### PR DESCRIPTION
This is a hacky first shot at #1124.
I am not liking it because it overrides user-defined `miter-limit` if they chose an explicit one for some reason.
Can someone provide guidance how to better raise this default value for *arrows markers* specifically so they remain pointy by default as most likely expected?
(My guess is that very few users want their arrow beveled, so we can pick a rather high default value.)