### PR TITLE
Require Typst 0.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
           crate: tytanic
       - uses: typst-community/setup-typst@v3
         with:
-          typst-version: '0.14.2'
+          typst-version: '0.15.1'
           cache-dependency-path: src/deps.typ
       - run: |
           typst --version

--- a/typst.toml
+++ b/typst.toml
@@ -1,7 +1,7 @@
 [package]
 name = "cetz"
 version = "0.5.3"
-compiler = "0.14.0"
+compiler = "0.15.0"
 repository = "https://github.com/cetz-package/cetz"
 homepage = "https://cetz-package.github.io/"
 entrypoint = "src/lib.typ"


### PR DESCRIPTION
#1127 relies on baseline propagation introduced in Typst 0.15.

This PR raises the minimum compiler version to 0.15.0 and updates CI to use Typst 0.15.1.

